### PR TITLE
aarch64 fix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ RUN apt-get update \
   # && apt-get -y install netcat gcc postgresql \
   && apt-get -y install nano curl \
   && apt-get -y install python3-watchdog \
+  && apt-get -y install libpq-dev \
   && apt-get -y install openjdk-11-jdk \
   && apt-get clean
 

--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -9,6 +9,6 @@ fastapi
 uvicorn
 
 sqlalchemy
-psycopg2-binary
+psycopg2==2.9.3
 
 ergo-python-appkit==0.1.0


### PR DESCRIPTION
App fails to connect to postgresql-14 db with following error on aarch64:
`sqlalchemy.exc.OperationalError: (psycopg2.OperationalError) SCRAM authentication requires libpq version 10 or above`

Fix described under: https://gitlab.com/testdriven/flask-react-auth/-/issues/4 resolved the issue.
